### PR TITLE
README, travis updates for alertlogic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,7 @@ before_install:
 script: "make get-deps compile test docs"
 
 otp_release:
-   - 17.0
+   - 19.1
+   - 18.3
+   - 17.5
    - R16B03-1
-   - R16B02
-   - R16B01
-   - R15B03
-   - R15B02
-   - R15B01

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-<!---
-@doc <!-- -->
+<a href="https://travis-ci.org/alertlogic/erl-cache" target="_blank"><img src="https://travis-ci.org/alertlogic/erl-cache.svg?branch=master"/></a>
+
+# erl-cache
+
+A generic in-node caching library with memoization support.
+
+This is a fork of [spilgames/erl-cache](https://github.com/spilgames/erl-cache) for [Alert Logic](https://github.com/alertlogic).
 
 <h3>Purpose</h3>
 
@@ -8,8 +13,6 @@ Do not expect a complex distributed application here. There are far more complex
 intended to act that way. Instead, erl_cache intends to be a simple solution that unifies common
 caching patterns within an erlang node which you probably have implemented a thousand times in one
 thousand slightly different ways. It's also a nice library if you want to do memoization in Erlang.
-
-<a href="https://travis-ci.org/spilgames/erl-cache" target="_blank"><img src="https://travis-ci.org/spilgames/erl-cache.svg?branch=master"/></a>
 
 <h3>Functional Description</h3>
 


### PR DESCRIPTION
* Make travis test current erlangs R16B03-1 to 19.1
* Update the README to use Alert Logic’s travis build status, note that we forked it.