### PR TITLE
alertlogic logging changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .eunit/
+.rebar/
 ebin/
+log/
 erl-project/
 deps/
 .dialyzer_plt

--- a/rebar.config
+++ b/rebar.config
@@ -5,8 +5,8 @@
 {cover_print_enabled,true}.
 
 {deps,[
-    {lager,[],{git,"git://github.com/spilgames/lager.git",{tag,"2.0.3"}}},
-    {decorator_pt,[],{git,"git://github.com/spilgames/erl-decorator-pt.git",{tag,"1.0.2"}}}
+    {lager, "", {git,"https://github.com/basho/lager.git", {tag, "1.2.2"}}},
+    {decorator_pt, "", {git,"git://github.com/spilgames/erl-decorator-pt.git", {tag, "1.0.2"}}}
 ]}.
 
 {deps_dir,"deps"}.

--- a/src/erl_cache.app.src
+++ b/src/erl_cache.app.src
@@ -5,8 +5,8 @@
   {registered, []},
   {applications, [
                   kernel,
-                  stdlib,
-                  lager
+                  stdlib % ,
+                  % lager % not starting lager; client applications can manage logging.
                  ]},
   {mod, { erl_cache_app, []}},
   {env, []}


### PR DESCRIPTION
* use basho lager 1.2.2
* don’t make lager an OTP dependency (let logging fail if lager isn’t running)