### PR TITLE
Add lager to application dependencies

### DIFF
--- a/src/erl_cache.app.src
+++ b/src/erl_cache.app.src
@@ -5,8 +5,8 @@
   {registered, []},
   {applications, [
                   kernel,
-                  stdlib % ,
-                  % lager % not starting lager; client applications can manage logging.
+                  stdlib,
+                  lager
                  ]},
   {mod, { erl_cache_app, []}},
   {env, []}


### PR DESCRIPTION
Erl-cache can not start-up without having lager as an application dependency as a lager call is made within the start-up code. This issue is overcome by adding lager back to the application dependency list.

```
Mar 27 11:02:56 CSV00002W ** Generic server erl_cache terminating 
** Last message in was {start_cache,ingestc_srv_enabled_cache,
                                    [{validity,570000},
                                     {error_validity,570000},
                                     {evict,30000},
                                     {evict_interval,60000},
                                     {wait_until_done,false},
                                     {wait_for_refresh,false}]}
** When Server state == {state,cache_map}
** Reason for termination == 
** {'module could not be loaded',
       [{lager,log,
            [info,<0.105.0>,"Starting cache server '~p'",
             [ingestc_srv_enabled_cache]],
            []},
        {erl_cache,do_start_cache,2,
            [{file,
                 "/Users/codyfriedrichsen/GitHub/ingestcli/_build/default/lib/erl_cache/src/erl_cache.erl"},
             {line,304}]},
        {erl_cache,handle_call,3,
            [{file,
                 "/Users/codyfriedrichsen/GitHub/ingestcli/_build/default/lib/erl_cache/src/erl_cache.erl"},
             {line,279}]},
        {gen_server,try_handle_call,4,[{file,"gen_server.erl"},{line,615}]},
        {gen_server,handle_msg,5,[{file,"gen_server.erl"},{line,647}]},
        {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,247}]}]}

Mar 27 11:02:56 CSV00090W erl_cache_sup <0.103.0> reports child UNKNOWN <0.105.0> terminated during child_terminated because {undef,[{lager,log,[info,<0.105.0>,"Starting cache server '~p'",[ingestc_srv_enabled_cache]],[]},{erl_cache,do_start_cache,2,[{file,"/Users/codyfriedrichsen/GitHub/ingestcli/_build/default/lib/erl_cache/src/erl_cache.erl"},{line,304}]},{erl_cache,handle_call,3,[{file,"/Users/codyfriedrichsen/GitHub/ingestcli/_build/default/lib/erl_cache/src/erl_cache.erl"},{line,279}]},{gen_server,try_handle_call,4,[{file,"gen_server.erl"},{line,615}]},{gen_server,handle_msg,5,[{file,"gen_server.erl"},{line,647}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,247}]}]}
```