### PR TITLE
Use error_logger directly for logging

### DIFF
--- a/include/logging.hrl
+++ b/include/logging.hrl
@@ -2,10 +2,10 @@
 %% Logging convenience functions
 %%============================================================================
 
--define(DEBUG(Msg, Args), _ = lager:log(debug, self(), Msg, Args)).
--define(INFO(Msg, Args), _ = lager:log(info, self(), Msg, Args)).
--define(NOTICE(Msg, Args), _ = lager:log(notice, self(), Msg, Args)).
--define(WARNING(Msg, Args), _ = lager:log(warning, self(), Msg, Args)).
--define(ERROR(Msg, Args), _ = lager:log(error, self(), Msg, Args)).
+-define(DEBUG(Msg, Args), _ = error_logger:info_msg(Msg, Args)).
+-define(INFO(Msg, Args), _ = error_logger:info_msg(Msg, Args)).
+-define(NOTICE(Msg, Args), _ = error_logger:warning_msg(Msg, Args)).
+-define(WARNING(Msg, Args), _ = error_logger:warning_msg(Msg, Args)).
+-define(ERROR(Msg, Args), _ = error_logger:error_msg(Msg, Args)).
 
 

--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,6 @@
 {cover_print_enabled,true}.
 
 {deps,[
-    {lager, "", {git, "https://github.com/basho/lager.git", {tag, "3.2.4"}}},
     {decorator_pt, "", {git,"git://github.com/spilgames/erl-decorator-pt.git", {tag, "1.0.2"}}}
 ]}.
 
@@ -27,5 +26,4 @@
 
 {erl_opts, [{platform_define, "^[0-9]+", 'namespace_types'},
             debug_info,
-           {src_dirs, [src]},
-           {parse_transform, lager_transform}]}.
+           {src_dirs, [src]}]}.

--- a/src/erl_cache.app.src
+++ b/src/erl_cache.app.src
@@ -5,8 +5,7 @@
   {registered, []},
   {applications, [
                   kernel,
-                  stdlib % ,
-                  % lager % not starting lager; client applications can manage logging.
+                  stdlib
                  ]},
   {mod, { erl_cache_app, []}},
   {env, []}

--- a/src/erl_cache.erl
+++ b/src/erl_cache.erl
@@ -125,7 +125,6 @@ main(Args) ->
 -spec start() -> ok.
 %% @end
 start() ->
-    ok = lager:start(),
     ok = application:start(erl_cache).
 
 %% @private


### PR DESCRIPTION
Remove the use of lager and use error_logger directly because the
halfway state of requiring lager code, but not depending on the
application causes Erlang release building to fail without some
other application declaring the dependency.