### PR TITLE
disable DEBUG logs, log purge_cache at DEBUG level

### DIFF
--- a/include/logging.hrl
+++ b/include/logging.hrl
@@ -2,10 +2,10 @@
 %% Logging convenience functions
 %%============================================================================
 
--define(DEBUG(Msg, Args), _ = error_logger:info_msg(Msg, Args)).
+%% error_logger does not support debug logging, so squelch it.
+% -define(DEBUG(Msg, Args), _ = error_logger:info_msg(Msg, Args)).
+-define(DEBUG(_Msg, _Args), ok).
 -define(INFO(Msg, Args), _ = error_logger:info_msg(Msg, Args)).
 -define(NOTICE(Msg, Args), _ = error_logger:warning_msg(Msg, Args)).
 -define(WARNING(Msg, Args), _ = error_logger:warning_msg(Msg, Args)).
 -define(ERROR(Msg, Args), _ = error_logger:error_msg(Msg, Args)).
-
-

--- a/src/erl_cache_server.erl
+++ b/src/erl_cache_server.erl
@@ -213,11 +213,11 @@ purge_cache(Name) ->
     end.
 
 purge_cache( Name, TableName, Now ) ->
-    {Time, Deleted} =
+    {_Time, Deleted} =
         timer:tc( ets, select_delete,
                   [TableName, [{#cache_entry{evict='$1', _='_'},
                                 [{'<', '$1', Now}], [true]}]] ),
-    ?INFO("~p cache purged in ~bms", [Name, Time]),
+    ?DEBUG("~p cache purged in ~bms", [Name, _Time]),
     gen_server:cast(Name, {increase_stat, evict, Deleted}),
     ok.
 


### PR DESCRIPTION
because #8 moved erl_cache from `lager` to `error_logger`, debug level logging is no longer possible. Instead of promoting it to info level, this change simply squelches it for now.

The cache purge message is annoying in caches that are short-lived. There is no reason to log this data at the info level. Log it at the debug level, so that, if debug logs are enabled in the future, it will be logged appropriately.