### PR TITLE
Add support for `{function(), [args()]}` callbacks

### DIFF
--- a/src/erl_cache.erl
+++ b/src/erl_cache.erl
@@ -88,7 +88,7 @@
                   | wait_until_done | evict_interval | error_validity | is_error_callback
                   | mem_check_interval | key_generation.
 
--type callback() :: function() | mfa().
+-type callback() :: function() | mfa() | {function(), [any()]}.
 
 -export_type([
         name/0, key/0, value/0, validity/0, evict/0, evict_interval/0, refresh_callback/0,
@@ -371,6 +371,10 @@ validate_value(Key, Opts, Defaults) when Key==refresh_callback; Key==is_error_ca
         undefined -> default(Key, Defaults);
         {M, F, A} when is_atom(M) andalso is_atom(F) andalso is_list(A) -> {M, F, A};
         Fun when is_function(Fun) -> Fun;
+        {Fun, Args} = FA
+          when is_function(Fun, length(Args)), Key==refresh_callback;
+               is_function(Fun, length(Args) + 1), Key==is_error_callback ->
+            FA;
         _ -> {invalid, Key}
     end;
 validate_value(Key, Opts, Defaults) when Key==validity; Key==evict_interval;

--- a/src/erl_cache_server.erl
+++ b/src/erl_cache_server.erl
@@ -279,9 +279,11 @@ check_mem_usage( Name, CurrentWords ) ->
     ok.
 
 %% @private
--spec do_apply(mfa() | function()) -> term().
+-spec do_apply(function() | mfa() | {function(), [any()]}) -> term().
 do_apply({M, F, A}) when is_atom(M), is_atom(F), is_list(A) ->
     apply(M, F, A);
+do_apply({F, A}) when is_function(F, length(A)) ->
+    apply(F, A);
 do_apply(F) when is_function(F) ->
     F().
 
@@ -289,6 +291,8 @@ do_apply(F) when is_function(F) ->
 -spec is_error_value(erl_cache:is_error_callback(), erl_cache:value()) -> boolean().
 is_error_value({M, F, A}, Value) ->
     apply(M, F, [Value|A]);
+is_error_value({F, A}, Value) ->
+    apply(F, [Value|A]);
 is_error_value(F, Value) when is_function(F) ->
     F(Value).
 

--- a/test/erl_cache_eunit.erl
+++ b/test/erl_cache_eunit.erl
@@ -118,7 +118,7 @@ refresh_overdue_async_mfa() ->
     ?assertEqual({error, not_found}, get_from_cache(test_key, [], 400)).
 
 refresh_overdue_sync_closure() ->
-    SetOpts = [{refresh_callback, fun() -> os:timestamp() end},
+    SetOpts = [{refresh_callback, {fun os:timestamp/0, []}},
                {validity, 50}, {evict, 300}],
     ?assertEqual({error, not_found}, get_from_cache(test_key, [], 1)),
     TestValue = os:timestamp(),
@@ -141,7 +141,7 @@ get_set_error() ->
     ?assertEqual({error, not_found}, get_from_cache(foo2, [])),
     set_in_cache(foo3, wrong, [{is_error_callback, {?MODULE, is_error, []}},
                                {error_validity, 1}, {wait_until_done, true}], 1),
-    set_in_cache(foo4, error, [{is_error_callback, {?MODULE, is_error, []}},
+    set_in_cache(foo4, error, [{is_error_callback, {fun is_error/1, []}},
                                {error_validity, 1}, {wait_until_done, true}], 1),
     ?assertEqual({error, not_found}, get_from_cache(foo3, [])),
     ?assertEqual({ok, error}, get_from_cache(foo4, [])).


### PR DESCRIPTION
Support ability to specify callbacks as:
```erlang
{fun some_function/2, [First, Second]}
```
Which is sometimes preferable to building anonymous functions and MFAs.

@motobob @nalundgaard please take a look,