### PR TITLE
Fix key generation module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ doc/edoc-info
 doc/doc
 tests/
 /erl_cache
+.rebar3

--- a/src/erl_cache_decorator.erl
+++ b/src/erl_cache_decorator.erl
@@ -11,9 +11,9 @@
 cache_pt(Fun, Args, {Module, FunctionAtom, Name, Opts}) ->
     FinalOpts = [{refresh_callback, fun () -> Fun(Args) end} | Opts],
     Key = case proplists:get_value(key_generation, Opts) of
-        Module when is_atom(Module) ->
-            apply(Module, generate_key, [Name, Module, FunctionAtom, Args]);
-        undefined ->
+        KeyModule when is_atom(KeyModule), KeyModule /= undefined ->
+            apply(KeyModule, generate_key, [Name, Module, FunctionAtom, Args]);
+        _ ->
             {decorated, Module, FunctionAtom, erlang:phash2(Args)}
     end,
     FromCache = erl_cache:get(Name, Key, FinalOpts),


### PR DESCRIPTION
Problem to solve:

- {key_generation, Module} (when using decorators) option only works if Module is the same as the module containing the decorator.