### PR TITLE
Add `erl_cacher:evict_all/1` function

### DIFF
--- a/src/erl_cache.erl
+++ b/src/erl_cache.erl
@@ -23,7 +23,8 @@
         start_link/0,
         stop_cache/1, start_cache/2,
         set_cache_defaults/2, get_cache_option/2,
-        evict/2, evict/3
+        evict/2, evict/3,
+        evict_all/1, evict_all/2
     ]).
 
 -ignore_xref([
@@ -253,6 +254,25 @@ evict(Name, Key, Opts) ->
             erl_cache_server:evict(Name, Key,
                                    proplists:get_value(wait_until_done, ValidatedOpts));
         {error, _}=E -> E
+    end.
+
+%% @see evict/2
+-spec evict_all(name()) -> ok | {error, invalid_opt_error()}.
+%% @end
+evict_all(Name) ->
+    evict_all(Name, []).
+
+%% @doc Forces eviction of all cache entries from cache instance
+-spec evict_all(name(), [cache_evict_opt()]) ->
+    ok | {error, invalid_opt_error()}.
+%% @end
+evict_all(Name, Opts) ->
+    case validate_opts(Opts, get_name_defaults(Name)) of
+        {ok, ValidatedOpts} ->
+            WaitUntilDone = proplists:get_value(wait_until_done, ValidatedOpts),
+            erl_cache_server:evict_all(Name, WaitUntilDone);
+        {error, _} = Error ->
+            Error
     end.
 
 %% ====================================================================

--- a/test/erl_cache_eunit.erl
+++ b/test/erl_cache_eunit.erl
@@ -89,7 +89,10 @@ default_get_set_evict() ->
     ?assertEqual({error, {invalid, cache_name}}, erl_cache:evict(nowhere, test_key)),
     ?assertEqual({error, not_found}, get_from_cache(test_key, [], 1)),
     ?assertEqual(ok, evict_from_cache(test_key2, [{wait_until_done, true}])),
-    ?assertEqual({error, not_found}, get_from_cache(test_key2, [])).
+    ?assertEqual({error, not_found}, get_from_cache(test_key2, [])),
+    ?assertEqual(ok, set_in_cache(test_key, <<"test_value">>)),
+    ?assertEqual(ok, evict_from_cache()),
+    ?assertEqual({error, not_found}, get_from_cache(test_key, [], 1)).
 
 refresh_undefined() ->
     SetOpts = [{refresh_callback, undefined}, {validity, 50}, {evict, 300}],
@@ -258,6 +261,9 @@ get_from_cache(K, Opts, 0) ->
 get_from_cache(K, Opts, SleepBefore) ->
     timer:sleep(SleepBefore),
     apply(erl_cache, get, [?TEST_CACHE, K, Opts]).
+
+evict_from_cache() ->
+    apply(erl_cache, evict_all, [?TEST_CACHE]).
 
 evict_from_cache(K) ->
     apply(erl_cache, evict, [?TEST_CACHE, K]).


### PR DESCRIPTION
This function is useful when we want to purge all the things from specified cache instance.

@motobob @nalundgaard please take a look,