### PR TITLE
Fix current memory usage computation

### DIFF
--- a/src/erl_cache_server.erl
+++ b/src/erl_cache_server.erl
@@ -279,7 +279,7 @@ check_mem_usage(Name) ->
 
 check_mem_usage( Name, CurrentWords ) ->
     MaxMB = erl_cache:get_cache_option(Name, max_cache_size),
-    CurrentMB = erlang:trunc((CurrentWords * erlang:system_info(wordsize)) / (1024*1024*8)),
+    CurrentMB = (CurrentWords * erlang:system_info(wordsize)) div (1024 * 1024),
     case MaxMB /= undefined andalso CurrentMB > MaxMB of
         true ->
             ?WARNING("~p exceeded memory limit of ~pMB: ~pMB in use! Forcing eviction...",

--- a/test/erl_cache_eunit.erl
+++ b/test/erl_cache_eunit.erl
@@ -169,7 +169,8 @@ mem_limit_forces_purge() ->
     timer:sleep(50),
     Stats = erl_cache:get_stats(?TEST_CACHE2),
     ?assertEqual(1, proplists:get_value(entries, Stats)),
-    V2 = [97 || _ <- lists:seq(1, 1024*1024*2)],
+    % Add ~2 MB cache entry. The size of V2 is 1 + 2 * (1024 * 1024 div wordsize) words
+    V2 = [0 || _ <- lists:seq(1, 1024 * 1024 div erlang:system_info(wordsize))],
     erl_cache:set(?TEST_CACHE2, k2, V2, [{validity, 1}, {evict, 0}, {wait_until_done, true}]),
     erl_cache:set(?TEST_CACHE2, k3, v3, [{validity, 1000}, {evict, 0}, {wait_until_done, true}]),
     timer:sleep(100),


### PR DESCRIPTION
* Fixes current memory usage computation in private `erl_cache_server:check_mem_usage/2` function which previously expected the wordsize returned by erlang:system_info(wordsize) to be returned in bits instead of bytes
* Lowers the size of the new entry added in the `mem_limit_forces_purge` unit test to ~2MB instead of ~30MB

This change fixes the current memory usage check that causes an immediate cache purge. The previous memory usage reported was off by a factor of 8 due to expecting the return of `erlang:system_info(wordsize)` to be in bits instead of bytes.