### PR TITLE
Reduce the risk of collision when using decorator.

### DIFF
--- a/src/erl_cache.app.src
+++ b/src/erl_cache.app.src
@@ -5,7 +5,8 @@
   {registered, []},
   {applications, [
                   kernel,
-                  stdlib
+                  stdlib,
+                  crypto
                  ]},
   {mod, { erl_cache_app, []}},
   {env, []}

--- a/src/erl_cache_decorator.erl
+++ b/src/erl_cache_decorator.erl
@@ -14,7 +14,7 @@ cache_pt(Fun, Args, {Module, FunctionAtom, Name, Opts}) ->
         KeyModule when is_atom(KeyModule), KeyModule /= undefined ->
             apply(KeyModule, generate_key, [Name, Module, FunctionAtom, Args]);
         _ ->
-            {decorated, Module, FunctionAtom, erlang:phash2(Args)}
+            {decorated, Module, FunctionAtom, crypto:hash(sha, erlang:term_to_binary(Args))}
     end,
     FromCache = erl_cache:get(Name, Key, FinalOpts),
     case FromCache of


### PR DESCRIPTION
Problem to solve:

- erl-cache decorators use erlang:phash2 to compute a unique argument-based subkey; this is the only thing differentiating multiple return values to the same function with different arguments
    - erlang:phash2 only has a key space of 2^27
    - cache lookup solely based on a hash are equivalent to a [birthday problem](https://en.wikipedia.org/wiki/Birthday_problem) with n being the number of entries in the cache, and d the key space width
    - considering a cache with only 1650 entries:
        - 1-pow(math.e, -pow(1650, 2)/(2*pow(2,27))) = ~ 1% chance of at least 1 collision
      which is much too high, especially if the cache may contain data belonging to multiple partitions (think cids)

Proposed solution:

1. either drastically expand the key space
    - using sha (2^160) brings the ~1% chance of collision to a cache containing 10^23
    - hash computation time are 2 to 4 times slower
    - it does require the crypto module
    - however it does not correct decorators using custom key generators
2. add an additional check in the cache verifying that the arguments indeed match
    - this requires to wrap values stored in the cache with arguments, so that we can store multiple values for a given hash
        - it would make maintaining the cache (eviction, expiration) much more complicated

For simplicity sake, option 1 is retained as good enough