### PR TITLE
Add support for hex publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+_build/
 .eunit/
 .rebar/
 ebin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: erlang
 
 before_install:
-       - wget https://raw.github.com/wiki/rebar/rebar/rebar
-       - chmod +x rebar
+  - wget https://raw.github.com/wiki/rebar/rebar/rebar
+  - chmod +x rebar
 
 script: "make get-deps compile test docs"
 
 otp_release:
-   - 19.1
-   - 18.3
-   - 17.5
-   - R16B03-1
+  - 22.0
+  - 21.3
+  - 20.3
+  - 19.3

--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 {cover_print_enabled,true}.
 
 {deps,[
-    {decorator_pt, "", {git,"git://github.com/spilgames/erl-decorator-pt.git", {tag, "1.0.2"}}}
+    {decorator_pt, "", {git,"https://github.com/alertlogic/erl-decorator-pt.git", {tag, "1.0.3-alertlogic"}}}
 ]}.
 
 {deps_dir,"deps"}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,0 +1,4 @@
+[{<<"decorator_pt">>,
+  {git,"https://github.com/alertlogic/erl-decorator-pt.git",
+       {ref,"146e5ce4e7b9bd4bd3dde1d3387959dd04ef189d"}},
+  0}].


### PR DESCRIPTION
* Update decorator_pt to pin to hex-published version from AL fork
* Update .gitignore for rebar3
* Update erlang versions in .travis.yml