### PR TITLE
Optimise common `get/2` path

### DIFF
--- a/src/erl_cache.erl
+++ b/src/erl_cache.erl
@@ -358,8 +358,12 @@ code_change(_OldVsn, State, _Extra) ->
     {ok, cache_opts()} | {error, invalid_opt_error()}.
 validate_opts(_, undefined) ->
     {error, {invalid, cache_name}};
+validate_opts([], Defaults) when Defaults =/= [] ->
+    %% Only called with `Defaults == []' during initialization of options.
+    %% Otherwise `Defaults' is passed as cached, validated, complete default set.
+    {ok, Defaults};
 validate_opts(Opts, Defaults) ->
-    CacheOpts = [validity, evict, refresh_callback, wait_for_refresh, max_cache_size,
+    CacheOpts = [wait_for_refresh, validity, evict, refresh_callback, max_cache_size,
                  wait_until_done, evict_interval, error_validity, is_error_callback,
                  mem_check_interval, key_generation],
     ValidationResults = [{K, validate_value(K, Opts, Defaults)} || K <- CacheOpts],


### PR DESCRIPTION
This commit optimises one of the most common erl-cache functions: `get(Cache, Key)`.
`validate_opts` appears to be taking significant chunk of time, especially if we're calling `get/2` thousands of times per second.
In my synthetic test - skipping validation for empty `Opts` provides ~2.5x speedup of `get/2`.

Also push `wait_for_refresh` on top of the validation list so later `proplists:get_value` matches faster in `get/3` (nano-optimisation).