### PR TITLE
Optimise `stats` collection in `erl_cache_server`

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -24,6 +24,7 @@
         protobuffs, velvet, goldrush
 ]}.
 
-{erl_opts, [{platform_define, "^[0-9]+", 'namespace_types'},
-            debug_info,
-           {src_dirs, [src]}]}.
+{erl_opts, [
+    debug_info,
+    {src_dirs, [src]}
+]}.


### PR DESCRIPTION
`dict:update_counter` implementation performs at ~1.3M/s updates on my machine.
Replacing it with static `#stats{}` record performs at ~14M/s updates.