### PR TITLE
Added match API to lookup items using partial key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-REBAR ?= rebar
-ifneq ($(wildcard rebar),)
-	REBAR := ./rebar
+REBAR ?= rebar3
+ifneq ($(wildcard rebar3),)
+	REBAR := ./rebar3
 endif
 
 .PHONY: clean test docs benchmark docsclean go quick dialyzer
@@ -12,22 +12,22 @@ get-deps:
 
 compile:
 	$(REBAR) compile
-	$(REBAR) skip_deps=true xref
+	$(REBAR) xref
 
 quick:
-	$(REBAR) skip_deps=true compile
-	$(REBAR) skip_deps=true xref
+	$(REBAR) compile
+	$(REBAR) xref
 
 clean:
 	$(REBAR) clean
 	rm -f erl_cache
 
 test: compile
-	$(REBAR) skip_deps=true eunit
+	$(REBAR) eunit
 
 docs: docsclean
 	ln -s . doc/doc
-	$(REBAR) skip_deps=true doc
+	$(REBAR) doc
 
 docsclean:
 	rm -f doc/*.html doc/*.css doc/erlang.png doc/edoc-info doc/doc
@@ -36,7 +36,7 @@ go:
 	erl -name erl_cache -pa deps/*/ebin -pa ebin/ -s erl_cache start ${EXTRA_ARGS}
 
 dialyzer:
-	dialyzer -c ebin/ -Wunmatched_returns -Werror_handling -Wrace_conditions
+	$(REBAR) dialyzer
 
 erl_cache:
 	REBAR_BENCH=1 $(REBAR) get-deps compile

--- a/src/erl_cache.erl
+++ b/src/erl_cache.erl
@@ -16,6 +16,7 @@
 
 -export([
         get/2, get/3,
+        match/2, match/3,
         get_stats/1,
         list_cache_servers/0,
         set/3, set/4,
@@ -204,6 +205,17 @@ get(Name, Key, Opts) ->
         {ok, ValidatedOpts} ->
             erl_cache_server:get(Name, Key, proplists:get_value(wait_for_refresh, ValidatedOpts));
         {error, _}=E -> E
+    end.
+
+match(Name, Key) ->
+    match(Name, Key, []).
+
+match(Name, Key, Opts) ->
+    case validate_opts(Opts, get_name_defaults(Name)) of
+        {ok, ValidatedOpts} ->
+            WaitForRefresh = proplists:get_value(wait_for_refresh, ValidatedOpts),
+            erl_cache_server:match(Name, Key, WaitForRefresh);
+        {error, _} = E -> E
     end.
 
 %% @doc Retrieves the stats associated with a cache instance

--- a/src/erl_cache_server.erl
+++ b/src/erl_cache_server.erl
@@ -12,6 +12,7 @@
 -export([
     start_link/1,
     get/3,
+    match/3,
     is_valid_name/1,
     set/9,
     evict/3,
@@ -69,22 +70,46 @@ start_link(Name) ->
 get(Name, Key, WaitForRefresh) ->
     Now = now_ms(),
     case ets:lookup(get_table_name(Name), Key) of
-        [#cache_entry{validity=Validity, value=Value}] when Now < Validity ->
-            gen_server:cast(Name, {increase_stat, hit}),
-            {ok, Value};
-        [#cache_entry{evict=Evict, value=Value, refresh_callback=undefined}] when Now < Evict ->
-            gen_server:cast(Name, {increase_stat, overdue}),
-            {ok, Value};
-        [#cache_entry{evict=Evict, refresh_callback=Cb}=Entry] when Now < Evict, Cb /=undefined ->
-            ?DEBUG("Refreshing overdue key ~p", [Key]),
-            gen_server:cast(Name, {increase_stat, overdue}),
-            {ok, NewVal} = refresh(Name, Entry, WaitForRefresh),
-            {ok, NewVal};
-        [#cache_entry{value=_ExpiredValue}] ->
-            {error, not_found};
+        [Entry] ->
+            send_stat(Name, Now, Entry),
+            case get_valid_value(Name, WaitForRefresh, Now, Entry) of
+                {true, Value} -> {ok, Value};
+                false -> {error, not_found}
+            end;
         [] ->
             gen_server:cast(Name, {increase_stat, miss}),
             {error, not_found}
+    end.
+
+send_stat(Name, Now, #cache_entry{validity=Validity}) when Now < Validity ->
+    gen_server:cast(Name, {increase_stat, hit});
+send_stat(Name, Now, #cache_entry{evict=Evict}) when Now < Evict ->
+    gen_server:cast(Name, {increase_stat, overdue});
+send_stat(_Name, _Now,  _) ->
+    ok.
+
+get_valid_value(_Name, _IsSync, Now, #cache_entry{validity=Validity} = E) when Now < Validity ->
+    {true, E#cache_entry.value};
+get_valid_value(Name, IsSync, Now, #cache_entry{evict=Evict} = E) when Now < Evict ->
+    refresh(Name, E, IsSync);
+get_valid_value(_Name, _IsSync, _Now, #cache_entry{value=_ExpiredValue}) ->
+    false.
+
+-spec match(erl_cache:name(), erl_cache:key(), erl_cache:wait_for_refresh()) ->
+    {ok, erl_cache:value()} | {error, not_found}.
+match(Name, Key, WaitForRefresh) ->
+    Now = now_ms(),
+    case ets:match_object(get_table_name(Name), #cache_entry{key = Key, _ = '_'}) of
+        [] ->
+            gen_server:cast(Name, {increase_stat, miss}),
+            {error, not_found};
+        Matches ->
+            lists:foreach(fun(E) -> send_stat(Name, Now, E) end, Matches),
+            IsValid = fun(E) -> get_valid_value(Name, WaitForRefresh, Now, E) end,
+            case lists:filtermap(IsValid, Matches) of
+                [] -> {error, not_found};
+                Values -> {ok, Values}
+            end
     end.
 
 -spec set(erl_cache:name(), erl_cache:key(), erl_cache:value(), pos_integer(), non_neg_integer(),
@@ -167,7 +192,7 @@ handle_cast(_Msg, State) ->
 
 %% @private
 -spec handle_info(any(), #state{}) -> {noreply, #state{}}.
-handle_info(purge_cache, #state{name=Name}=State) ->
+handle_info(purge_cache, #state{name=Name} = State) ->
     purge_cache(Name),
     EvictInterval = erl_cache:get_cache_option(Name, evict_interval),
     {ok, _} = timer:send_after(EvictInterval, Name, purge_cache),
@@ -241,21 +266,21 @@ purge_cache( Name, TableName, Now ) ->
 %% @private
 -spec refresh(erl_cache:name(), #cache_entry{}, erl_cache:wait_for_refresh()) ->
     {ok, erl_cache:value()}.
-refresh(Name, #cache_entry{refresh_callback=Callback}=Entry, true) when Callback/=undefined ->
-    NewVal = do_refresh(Name, Entry, true),
-    {ok, NewVal};
-refresh(Name, #cache_entry{value=Value, refresh_callback=Callback}=Entry, false)
-        when Callback/=undefined ->
-    F = fun () -> do_refresh(Name, Entry, false) end,
-    _ = spawn(F),
-    {ok, Value}.
+refresh(_Name, #cache_entry{refresh_callback=undefined} = Entry, _WaitForRefresh) ->
+    {true, Entry#cache_entry.value};
+refresh(Name, #cache_entry{} = Entry, true) ->
+    {true, do_refresh(Name, Entry, true)};
+refresh(Name, #cache_entry{} = Entry, false) ->
+    spawn(fun () -> do_refresh(Name, Entry, false) end),
+    {true, Entry#cache_entry.value}.
 
 %% @private
 -spec do_refresh(erl_cache:name(), #cache_entry{}, erl_cache:wait_for_refresh()) ->
     erl_cache:value().
-do_refresh(Name, #cache_entry{key=Key, validity_delta=ValidityDelta, evict_delta=EvictDelta,
-                              refresh_callback=Callback, is_error_callback=IsErrorCb}=Entry,
-           WaitForRefresh) ->
+do_refresh(Name, #cache_entry{} = Entry, WaitForRefresh) ->
+    #cache_entry{key=Key, validity_delta=ValidityDelta, evict_delta=EvictDelta,
+                 refresh_callback=Callback, is_error_callback=IsErrorCb} = Entry,
+    ?DEBUG("Refreshing overdue key ~p", [Key]),
     NewVal = do_apply(Callback),
     Now = now_ms(),
     RefreshedEntry = case is_error_value(IsErrorCb, NewVal) of


### PR DESCRIPTION
This change allows caching an item with a compound key and look up a list of items matching only some part of the key.

Changes also include bringing the makefile up-to-date.