### PR TITLE
Propagate cache stats from ets operations and fix dialyzer issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ doc/doc
 tests/
 /erl_cache
 .rebar3
+TEST-*.xml

--- a/src/erl_cache.erl
+++ b/src/erl_cache.erl
@@ -91,7 +91,7 @@
                   | wait_until_done | evict_interval | error_validity | is_error_callback
                   | mem_check_interval | key_generation.
 
--type callback() :: function() | mfa() | {function(), [any()]}.
+-type callback() :: function() | {module(), atom(), [term()]} | {function(), [term()]}.
 
 -export_type([
         name/0, key/0, value/0, validity/0, evict/0, evict_interval/0, refresh_callback/0,
@@ -165,7 +165,7 @@ set_cache_defaults(Name, CacheOpts) ->
     end.
 
 %% @doc Gets the default value of a cache server option.
--spec get_cache_option(name(), cache_opts()) -> term().
+-spec get_cache_option(name(), config_key()) -> term().
 %% @end
 get_cache_option(Name, Opt) ->
     case ets:lookup(?CACHE_MAP, Name) of

--- a/src/erl_cache_decorator.erl
+++ b/src/erl_cache_decorator.erl
@@ -1,31 +1,50 @@
 -module(erl_cache_decorator).
+-behaviour(erl_cache_key_generator).
 
 -export([cache_pt/3]).
+-export([generate_key/4]).
 
 %% ====================================================================
 %% API
 %% ====================================================================
-
--spec cache_pt(function(), [term()], {atom(), atom(), erl_cache:name(), erl_cache:cache_opts()}) ->
-    (fun(() -> term())).
+-spec cache_pt(Fun, Args, Decoration) -> Arity0Fun when
+      Fun::function(),
+      Args::[term()],
+      Decoration::{Module::module(), FunctionAtom::atom(), Name, Opts},
+      Name::erl_cache:name(),
+      Opts::erl_cache:cache_opts(),
+      Arity0Fun::fun(() -> term()).
 cache_pt(Fun, Args, {Module, FunctionAtom, Name, Opts}) ->
-    FinalOpts = [{refresh_callback, fun () -> Fun(Args) end} | Opts],
-    Key = case proplists:get_value(key_generation, Opts) of
-        KeyModule when is_atom(KeyModule), KeyModule /= undefined ->
-            apply(KeyModule, generate_key, [Name, Module, FunctionAtom, Args]);
-        _ ->
-            {decorated, Module, FunctionAtom, crypto:hash(sha, erlang:term_to_binary(Args))}
-    end,
-    FromCache = erl_cache:get(Name, Key, FinalOpts),
-    case FromCache of
-        {ok, Result} -> fun() -> Result end;
+    KeyModule = case proplists:get_value(key_generation, Opts) of
+                    undefined -> ?MODULE;
+                    KeyMod when is_atom(KeyMod) -> KeyMod;
+                    _ -> ?MODULE
+                end,
+    Key = KeyModule:generate_key(Name, Module, FunctionAtom, Args),
+    GetOpts = proplists:lookup_all(wait_for_refresh, Opts),
+    case erl_cache:get(Name, Key, GetOpts) of
+        {ok, Result} ->
+            fun() -> Result end;
         {error, not_found} ->
-            fun () ->
-                    Res = Fun(Args),
-                    ok = erl_cache:set(Name, Key, Res, FinalOpts),
-                    Res
-            end;
+            Curried = fun() -> Fun(Args) end,
+            cache_setter(Name, Key, Curried, Opts);
         {error, Err} ->
             throw({error, {cache_pt, Err}})
     end.
 
+%% ====================================================================
+%% Behaviour callback
+%% ====================================================================
+generate_key(_Name,  Module, FunctionAtom, Args) ->
+    {decorated, Module, FunctionAtom, crypto:hash(sha, erlang:term_to_binary(Args))}.
+
+%% ====================================================================
+%% Internal
+%% ====================================================================
+cache_setter(Name, Key, Curried, Opts) ->
+    SetOpts = [{refresh_callback, Curried} | proplists:delete(wait_for_refresh, Opts)],
+    fun() ->
+            Value = Curried(),
+            ok = erl_cache:set(Name, Key, Value, SetOpts),
+            Value
+    end.

--- a/src/erl_cache_key_generator.erl
+++ b/src/erl_cache_key_generator.erl
@@ -7,5 +7,9 @@
 %%
 %% The way to fix this issue is modifying how erl_decorator_pt deals with the
 %% intermediate code representation.
--callback generate_key(CacheInstance::erl_cache:name(), Module::atom(),
-                       Function::atom(), Args::[term()]) -> erl_cache:key().
+-callback generate_key(Name, Module, Function, Args) -> Key when
+      Name::erl_cache:name(),
+      Module::module(),
+      Function::atom(),
+      Args::[term()],
+      Key::erl_cache:key().

--- a/src/erl_cache_server.erl
+++ b/src/erl_cache_server.erl
@@ -58,7 +58,7 @@
     is_error_callback::undefined|'_'|erl_cache:is_error_callback()
 }).
 
--type cache_operation()::fun((erl_cache:cache_name(), #cache_entry{}) -> non_neg_integer()).
+-type cache_operation()::fun((erl_cache:name(), #cache_entry{}) -> non_neg_integer()).
 
 %% ==================================================================
 %% API Function Definitions

--- a/test/erl_cache_eunit.erl
+++ b/test/erl_cache_eunit.erl
@@ -118,6 +118,8 @@ refresh_overdue_async_mfa() ->
     % The value should have been asynchronously refreshed
     ?assertMatch({ok, T} when is_tuple(T) andalso T/=TestValue,
                  get_from_cache(test_key, [{wait_for_refresh, false}], 10)),
+    ?assertMatch({ok, T} when is_tuple(T) andalso T/=TestValue,
+                 get_from_cache(test_key, [{wait_for_refresh, true}], 10)),
     % At this point the value should have been evicted
     ?assertEqual({error, not_found}, get_from_cache(test_key, [], 400)).
 


### PR DESCRIPTION
### Functional
* Remove the special case of `operate_cache/1` where `{increase_stat, StatName}` would be used to bump-up the cache-statistic for the named operation.
* Ensure instead that the 3-tuple: `{increase_stat, StatName, Increment}` is used for every cache-operation. The actual `Increment` then can be propagated from the `ets` operations (or just defined as `1` for a singular change).

### Type-checking
* Define cache-operation function type
* Use arguments known at compile-time when applying cache-operation function(s) ([more efficient](https://www.erlang.org/doc/efficiency_guide/functions.html#function-calls) and [better written](https://www.erlang.org/doc/man/erlang.html#apply-2)).
* Fix dialyzer issues within the `erl_cache_server` module
* Fix no-local-return of decorator: `cache_pt/3`
* Fix incorrect type-descriptions in the `erl_cache` module

### Non-code
* Ignore test artefacts